### PR TITLE
Add instructions for running hackingtoolkit and Sn1per installation scripts together

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,15 @@ https://github.com/The404Hacking/Sn1per/blob/master/Sn1per-v1.5-report
 [Instagram](https://instagram.com/The404Hacking) - [GitHub](https://github.com/The404Hacking)
 
 [YouTube](http://yon.ir/youtube404) - [Aparat](http://www.aparat.com/The404Hacking)
+
+## Running hackingtoolkit and Sn1per together:
+```
+chmod +x hackingtoolkit
+cd hackingtoolkit
+sudo python3 htk.py
+
+git clone https://github.com/The404Hacking/Sn1per.git
+cd Sn1per
+chmod +x install.sh
+./install.sh
+```

--- a/hackingtoolkit
+++ b/hackingtoolkit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Ensure the script is executable
+chmod +x hackingtoolkit
+
+# Execute the hackingtoolkit script
+cd hackingtoolkit
+sudo python3 htk.py

--- a/install.sh
+++ b/install.sh
@@ -106,5 +106,13 @@ ln -s $PLUGINS_DIR/Findsploit/copysploit /usr/bin/copysploit
 ln -s $PLUGINS_DIR/Findsploit/compilesploit /usr/bin/compilesploit
 ln -s $PLUGINS_DIR/MassBleed/massbleed /usr/bin/massbleed
 ln -s $PLUGINS_DIR/testssl.sh/testssl.sh /usr/bin/testssl
+
+# Ensure hackingtoolkit script is executable
+chmod +x hackingtoolkit
+
+# Execute hackingtoolkit script
+cd hackingtoolkit
+sudo python3 htk.py
+
 echo -e "$OKORANGE + -- --=[Done!$RESET"
 echo -e "$OKORANGE + -- --=[To run, type 'sniper'! $RESET"


### PR DESCRIPTION
Add instructions for running hackingtoolkit and Sn1per together.

* **README.md**
  - Add a new section with instructions for running the `hackingtoolkit` and Sn1per installation scripts together.

* **install.sh**
  - Add steps to ensure the `hackingtoolkit` script is executable.
  - Add steps to execute the `hackingtoolkit` script before installing Sn1per.

* **hackingtoolkit**
  - Add the `hackingtoolkit` script to the repository.
  - Ensure the script is executable and ready to run.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/The404Hacking/Sn1per/pull/2?shareId=bd9d4f61-3f23-45a8-bd1f-1e3a52a127e1).